### PR TITLE
update rules and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/packages/eslint-config-kununu/README.md
+++ b/packages/eslint-config-kununu/README.md
@@ -4,20 +4,15 @@
 
 ## Install
 
-This contains ESLint rules for ECMAScript 6+, React and Flow. It requires `eslint`, `eslint-plugin-babel`, `eslint-plugin-flowtype`, `eslint-plugin-import`, `eslint-plugin-jsx-a11y`, and `eslint-plugin-react`.
+This contains ESLint rules for ECMAScript 6+ and React. It requires `eslint`, `babel-eslint`,`eslint-plugin-babel`, `eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, and `eslint-import-resolver-alias` as peer dependencies.
 
 1. Add these npm packages as dev dependencies to your project:
-  ```sh
-  (
-    export PKG=@kununu/eslint-config;
-    npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG@latest"
-  )
   ```
-
-  Which produces and runs a command like:
-
-  ```sh
-  npm install --save-dev @kununu/eslint-config eslint@^#.#.# eslint-plugin-babel@^#.#.# eslint-plugin-flowtype@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-react@^#.#.#
+  npx install-peerdeps --dev @kununu/eslint-config
+  ```
+  Alternatively you can install the peer dependencies manually like this:
+  ```
+  npm install --save-dev @kununu/eslint-config babel-eslint@10.0.1 eslint@5.10.0 eslint-plugin-babel@5.3.0 eslint-plugin-import@2.14.0 eslint-plugin-jsx-a11y@6.1.2 eslint-plugin-react@7.11.1 eslint-import-resolver-alias@1.1.2
   ```
 
 2. Add `"extends": "@kununu"` to your .eslintrc

--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -58,10 +58,18 @@ module.exports = {
       specialLink: ['to'],
     }],
 
-    // https://eslint.org/docs/rules/object-curly-newline
-    'object-curly-newline': ['error', {multiline: true}],
-
     // https://eslint.org/docs/rules/operator-linebreak
     'operator-linebreak': ['error', 'after'],
+
+    // https://eslint.org/docs/rules/no-confusing-arrow
+    // turn off to prevent conflict with 
+    // https://eslint.org/docs/rules/arrow-body-style
+    'no-confusing-arrow': 'off',
+
+    // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
+    // 'label' tags need 'htmlFor' prop, but nesting is not required
+    'jsx-a11y/label-has-for': [ 2, {
+      'required': 'id',
+    }],
   },
 };

--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -68,8 +68,20 @@ module.exports = {
 
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
     // 'label' tags need 'htmlFor' prop, but nesting is not required
-    'jsx-a11y/label-has-for': [ 2, {
+    'jsx-a11y/label-has-for': [ 'error', {
       'required': 'id',
     }],
+
+    // https://eslint.org/docs/rules/padding-line-between-statements
+    // enforce empty lines after variable declarations
+    'padding-line-between-statements': ['error', {
+      'blankLine': 'always', 'prev': ['const', 'let', 'var'], 'next': '*'
+    }, {
+      'blankLine': 'any', 'prev': ['const', 'let', 'var'], 'next': ['const', 'let', 'var']
+    }],
+
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
+    // jsx props should be on separate lines each
+    'react/jsx-max-props-per-line': ['error', {'maximum': 1}]
   },
 };

--- a/packages/eslint-config-kununu/package-lock.json
+++ b/packages/eslint-config-kununu/package-lock.json
@@ -1,29 +1,134 @@
 {
   "name": "@kununu/eslint-config",
-  "version": "1.0.1",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "eslint-config-airbnb": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz",
-      "integrity": "sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==",
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
-        "eslint-config-airbnb-base": "12.1.0"
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "requires": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "eslint-config-airbnb": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz",
+      "integrity": "sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==",
+      "requires": {
+        "eslint-config-airbnb-base": "^13.1.0",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz",
-      "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz",
+      "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
       "requires": {
-        "eslint-restricted-globals": "0.1.1"
+        "eslint-restricted-globals": "^0.1.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
       }
     },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
       "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
+      }
     }
   }
 }

--- a/packages/eslint-config-kununu/package.json
+++ b/packages/eslint-config-kununu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/eslint-config",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "kununu's ESLint config",
   "main": "index.js",
   "scripts": {
@@ -21,15 +21,15 @@
   },
   "homepage": "https://github.com/kununu/javascript#readme",
   "dependencies": {
-    "eslint-config-airbnb": "17.0.0"
+    "eslint-config-airbnb": "17.1.0"
   },
   "peerDependencies": {
-    "babel-eslint": "8.2.5",
-    "eslint": "5.0.1",
-    "eslint-plugin-babel": "5.1.0",
-    "eslint-plugin-import": "2.13.0",
-    "eslint-plugin-flowtype": "2.49.3",
-    "eslint-plugin-jsx-a11y": "6.0.3",
-    "eslint-plugin-react": "7.10.0"
+    "babel-eslint": "10.0.1",
+    "eslint": "5.10.0",
+    "eslint-plugin-babel": "5.3.0",
+    "eslint-plugin-import": "2.14.0",
+    "eslint-plugin-jsx-a11y": "6.1.2",
+    "eslint-plugin-react": "7.11.1",
+    "eslint-import-resolver-alias": "1.1.2"
   }
 }


### PR DESCRIPTION
These updates reflect the changes I am making for fixing the linting of app-reviews.

The only controversial change I see is the removal of 
```
'object-curly-newline': ['error', {multiline: true}]
```
The reason being that this rule currently disallows certain (voluntary and optional) line breaks in object expressions such as:
```
const test = {
  meow: {
    test: dispatch => 'hi',
  },
};
```
Removing the rule here means that AirBnB's rule is not overwritten anymore. That rule is more permissive and allows certain format versions I feel we do not really like, such as:
```
const test = {meow: {test: dispatch => 'hi'}};
```
But the only way I see to enforce line breaks in such cases would be to enforce line breaks everywhere. And that would be overdoing it imo. It would for example require a line break for `{flag: false}` or even `{}`.
Out of curiosity I tried turning it on for app-reviews and immediately had > 1500 errors. 

I believe the way to go is to keep AirBnB's permissive rule and keeping in mind to add line breaks manually while writing the code.