### PR TITLE
Update dependencies

### DIFF
--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -28,7 +28,7 @@ module.exports = {
     'max-len': 'off', // Sometimes longer lines are more readable (Airbnb rule change)
     'no-param-reassign': ['error', {props: false}],
     'no-prototype-builtins': 'off', // Objects aren't created that don't extend from Object.prototype (Airbnb rule change)
-    'object-curly-spacing': 'off', // Disabled in favor of babel/object-curly-spacing in order to avoid false positives with ECMAScript modules (Airbnb rule change)
+    'object-curly-spacing': 'off', // Disabled in favor of @babel/object-curly-spacing in order to avoid false positives with ECMAScript modules (Airbnb rule change)
     'space-before-function-paren': ['error', {
       anonymous: 'always', // const foo = function () {}
       named: 'always', // function foo () {} (Airbnb rule change)
@@ -38,8 +38,8 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
     'react/no-direct-mutation-state': 'error', // Use .setState() always (Airbnb rule change)
 
-    // https://github.com/babel/eslint-plugin-babel#rules
-    'babel/object-curly-spacing': 'error', // No spaces in single-line objects to make nested objects like {a: {b: 'c'}} look more sane (Airbnb rule change)
+    // https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin#rules
+    "@babel/object-curly-spacing": "error", // No spaces in single-line objects to make nested objects like {a: {b: 'c'}} look more sane (Airbnb rule change)
 
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/
     'import/order': ['error', { // Make import sort order an error (Airbnb rule change)

--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -139,8 +139,12 @@ module.exports = {
     }],
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md
-    // enforce the state initialization style to be either in a constructor or with a class property
+    // enforces the state initialization style to be either in a constructor or with a class property
     'react/state-in-constructor': 'off',
+
+    // https://eslint.org/docs/rules/arrow-parens
+    // enforces no braces where they can be omitted
+    'arrow-parens': ['error', 'as-needed']
   },
 
   overrides: [{

--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -144,6 +144,7 @@ module.exports = {
     rules: {
       'global-require': 'off',
       'jsx-a11y/anchor-is-valid': 'off',
+      'react/jsx-props-no-spreading': 'off'
     }
   }]
 };

--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -39,7 +39,7 @@ module.exports = {
     'react/no-direct-mutation-state': 'error', // Use .setState() always (Airbnb rule change)
 
     // https://github.com/babel/babel/tree/main/eslint/babel-eslint-plugin#rules
-    "@babel/object-curly-spacing": "error", // No spaces in single-line objects to make nested objects like {a: {b: 'c'}} look more sane (Airbnb rule change)
+    '@babel/object-curly-spacing': 'error', // No spaces in single-line objects to make nested objects like {a: {b: 'c'}} look more sane (Airbnb rule change)
 
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/
     'import/order': ['error', { // Make import sort order an error (Airbnb rule change)
@@ -134,8 +134,8 @@ module.exports = {
 
     // https://eslint.org/docs/rules/indent
     // enforces a consistent 2 spaces indentation style
-    "indent": ["error", 2, {
-      "SwitchCase": 1
+    'indent': ['error', 2, {
+      'SwitchCase': 1
     }],
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md

--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -144,7 +144,14 @@ module.exports = {
 
     // https://eslint.org/docs/rules/arrow-parens
     // enforces no braces where they can be omitted
-    'arrow-parens': ['error', 'as-needed']
+    'arrow-parens': ['error', 'as-needed'],
+
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
+    'import/extensions': ['error', 'ignorePackages', {
+      'js': 'never',
+      'jsx': 'never',
+      'scss': 'ignorePackages'
+    }],
   },
 
   overrides: [{

--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -1,10 +1,10 @@
 module.exports = {
   extends: 'airbnb', // Many strict rules for ECMAScript and React
 
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
 
   plugins: [
-    'babel',
+    '@babel',
     'react-hooks',
   ],
 
@@ -131,6 +131,12 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/static-property-placement.md
     // enforces where React component static properties should be positioned
     'react/static-property-placement': ['error', 'property assignment'],
+
+    // https://eslint.org/docs/rules/indent
+    // enforces a consistent 2 spaces indentation style
+    "indent": ["error", 2, {
+      "SwitchCase": 1
+    }]
   },
 
   overrides: [{

--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -136,7 +136,11 @@ module.exports = {
     // enforces a consistent 2 spaces indentation style
     "indent": ["error", 2, {
       "SwitchCase": 1
-    }]
+    }],
+
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md
+    // enforce the state initialization style to be either in a constructor or with a class property
+    'react/state-in-constructor': 'off',
   },
 
   overrides: [{

--- a/packages/eslint-config-kununu/index.js
+++ b/packages/eslint-config-kununu/index.js
@@ -152,6 +152,13 @@ module.exports = {
       'jsx': 'never',
       'scss': 'ignorePackages'
     }],
+
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md
+    // disallow spread on html tags directly but allows it on React components
+    'react/jsx-props-no-spreading': ['error', {
+      'html': 'enforce',
+      'custom': 'ignore',
+    }]
   },
 
   overrides: [{
@@ -159,7 +166,6 @@ module.exports = {
     rules: {
       'global-require': 'off',
       'jsx-a11y/anchor-is-valid': 'off',
-      'react/jsx-props-no-spreading': 'off'
     }
   }]
 };

--- a/packages/eslint-config-kununu/package.json
+++ b/packages/eslint-config-kununu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/eslint-config",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "description": "kununu's ESLint config",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-kununu/package.json
+++ b/packages/eslint-config-kununu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/eslint-config",
-  "version": "1.3.0-beta.3",
+  "version": "1.3.0",
   "description": "kununu's ESLint config",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-kununu/package.json
+++ b/packages/eslint-config-kununu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/eslint-config",
-  "version": "1.3.0-beta.0",
+  "version": "1.3.0-beta.1",
   "description": "kununu's ESLint config",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-kununu/package.json
+++ b/packages/eslint-config-kununu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/eslint-config",
-  "version": "1.3.0-beta.2",
+  "version": "1.3.0-beta.3",
   "description": "kununu's ESLint config",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-kununu/package.json
+++ b/packages/eslint-config-kununu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/eslint-config",
-  "version": "1.2.1",
+  "version": "1.3.0-beta.0",
   "description": "kununu's ESLint config",
   "main": "index.js",
   "scripts": {
@@ -21,14 +21,15 @@
   },
   "homepage": "https://github.com/kununu/javascript#readme",
   "dependencies": {
-    "babel-eslint": "10.0.2",
-    "eslint": "6.1.0",
-    "eslint-config-airbnb": "17.1.1",
+    "@babel/core": "7.13.8",
+    "@babel/eslint-parser": "7.13.8",
+    "@babel/eslint-plugin": "7.13.0",
+    "eslint": "7.21.0",
+    "eslint-config-airbnb": "18.2.1",
     "eslint-import-resolver-alias": "1.1.2",
-    "eslint-plugin-babel": "5.3.0",
-    "eslint-plugin-import": "2.18.2",
-    "eslint-plugin-jsx-a11y": "6.2.3",
-    "eslint-plugin-react": "7.14.3",
-    "eslint-plugin-react-hooks": "1.6.1"
+    "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-jsx-a11y": "6.4.1",
+    "eslint-plugin-react": "7.22.0",
+    "eslint-plugin-react-hooks": "4.2.0"
   }
 }

--- a/packages/eslint-config-kununu/package.json
+++ b/packages/eslint-config-kununu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/eslint-config",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "kununu's ESLint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Description

- Updated all dependencies to their respective latest versions, and with that was necessary to change eslint parser from `babel-eslint` to `@babel/eslint-parser`, For further information you can check out [this repo](https://github.com/babel/babel-eslint). Also the same as needed to `eslint-plugin-babel`, which migrated to `@babel/eslint-plugin`, you can check it out  [this repo](https://github.com/babel/eslint-plugin-babel). 
- Migrated rule `babel/object-curly-spacing` to be `@babel/object-curly-spacing`.
- Added `indent` rule. This will help us to have a more consistent codebase. If we move to prettier you can safely remove it later. By @catarina-lopes-pt 
- Disabled `react/jsx-props-no-spreading`  for testing files.
- Disabled `react/state-in-constructor` as we can use class fields.
- Overrode `arrow-parens` to only require parenthesis when is really necessary
- Overrode `import/extensions` to make it work with our `scss` extension files.

# Questions

`@babel/eslint-parser` requires `@babel/core` , for now I just included in as a dependency, but seems like have it as a `peerDependency` on this package would be more suitable, as if we wanted a more updated of the latter we wouldn't have to release a version of `@kununu/eslint-config`. What do you think?

# DO before merge

- [x] Update package.json version to 2.0.0

# Released versions

- [1.3.0-beta.5](https://www.npmjs.com/package/@kununu/eslint-config/v/1.3.0-beta.5)
- [1.3.0-beta.4](https://www.npmjs.com/package/@kununu/eslint-config/v/1.3.0-beta.4)
- [1.3.0-beta.3](https://www.npmjs.com/package/@kununu/eslint-config/v/1.3.0-beta.3)


