### PR TITLE
Utils implementation: httpHeaderFilter

### DIFF
--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/utils",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,7 +2,7 @@
   "name": "@kununu/utils",
   "author": "kununu",
   "license": "ISC",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "Hosts react utils to be used cross application.",
   "main": "dist/",
   "scripts": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,5 @@
 
 import getUrl from './utils/getUrl';
+import httpHeaderFilter from './utils/httpHeaderFilter';
 
-// eslint-disable-next-line import/prefer-default-export
-export {getUrl};
+export {getUrl, httpHeaderFilter};

--- a/packages/utils/src/utils/httpHeaderFilter/index.spec.ts
+++ b/packages/utils/src/utils/httpHeaderFilter/index.spec.ts
@@ -1,0 +1,45 @@
+
+import httpHeaderFilter from '.';
+
+describe('httpHeaderFilter', () => {
+  const headers = {
+    'accept-encoding': 'gzip, deflate, br',
+    'accept-language': 'en-GB,en-US;q=0.9,en;q=0.8,pt;q=0.7',
+    host: 'www-local.dev.kununu.it',
+    'if-none-match': '"1356a-OJvJVy+YANooKfI0dxSZMg0oCHI"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-fetch-dest': 'document',
+    'sec-fetch-mode': 'navigate',
+    'sec-fetch-site': 'same-origin',
+    'upgrade-insecure-requests': '1',
+    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36',
+    'x-forwarded-for': '10.42.0.1',
+    'x-forwarded-host': 'www-local.dev.kununu.it',
+    'x-forwarded-port': '443',
+    'x-forwarded-proto': 'https',
+    'x-forwarded-server': 'traefik-56b8f85885-hmcvj',
+    'X-Lang': 'de_DE',
+    'x-new-profiles': '1',
+    'x-real-ip': '10.42.0.1',
+  };
+
+  const filteredHeaders = {
+    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36',
+    'x-forwarded-for': '10.42.0.1',
+    'x-forwarded-host': 'www-local.dev.kununu.it',
+    'x-forwarded-port': '443',
+    'x-forwarded-proto': 'https',
+    'x-forwarded-server': 'traefik-56b8f85885-hmcvj',
+    'X-Lang': 'de_DE',
+  };
+
+  it('should return the headers filtered', () => {
+    expect(httpHeaderFilter(headers)).toEqual(filteredHeaders);
+  });
+
+  it('should return the headers filtered with the additional allowed headers', () => {
+    const additionalAllowed = ['x-new-profiles'];
+
+    expect(httpHeaderFilter(headers, additionalAllowed)).toEqual({...filteredHeaders, 'x-new-profiles': '1'});
+  });
+});

--- a/packages/utils/src/utils/httpHeaderFilter/index.ts
+++ b/packages/utils/src/utils/httpHeaderFilter/index.ts
@@ -1,0 +1,27 @@
+const allowedHeaders = [
+  'x-amzn-trace-id',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-port',
+  'x-forwarded-proto',
+  'x-forwarded-server',
+  'user-agent',
+  'referer',
+  'origin',
+  'X-Lang',
+];
+
+const httpHeaderFilter = (
+  headers: Record<string, string>,
+  additionalAllowed = [],
+): Record<string, string> => Object.keys(headers)
+  .filter(key => allowedHeaders.concat(additionalAllowed).includes(key))
+  .reduce(
+    (obj, key) => ({
+      ...obj,
+      [key]: headers[key],
+    }),
+    {},
+  );
+
+export default httpHeaderFilter;


### PR DESCRIPTION
### httpHeaderFilter - version to test: 1.0.0-beta.1

- [x] move code
- [x] improve code (typescript)
- [x] implement tests
- [x] test on app-sitemaps
- [x] test on app-profiles