### PR TITLE
Utils implementation: setApiHeaders

### DIFF
--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kununu/utils",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,7 +2,7 @@
   "name": "@kununu/utils",
   "author": "kununu",
   "license": "ISC",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.6",
   "description": "Hosts react utils to be used cross application.",
   "main": "dist/",
   "scripts": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,6 +3,7 @@ import getUrl from './utils/getUrl';
 import httpHeaderFilter from './utils/httpHeaderFilter';
 import isClientRender from './utils/isClientRender';
 import buildHTTPHeaders from './utils/buildHTTPHeaders';
+import setApiHeaders from './utils/setApiHeaders';
 import {
   getCountriesByLocale,
   getCountryByLocale,
@@ -19,4 +20,5 @@ export {
   isClientRender,
   isDach,
   isUSLocale,
+  setApiHeaders,
 };

--- a/packages/utils/src/utils/setApiHeaders/index.spec.ts
+++ b/packages/utils/src/utils/setApiHeaders/index.spec.ts
@@ -1,0 +1,13 @@
+import setApiHeaders, {defaultHeaders} from '.';
+
+describe('setApiHeaders', () => {
+  it('should return only the default headers', () => {
+    expect(setApiHeaders()).toEqual(defaultHeaders);
+  });
+
+  it('should return the default headers + the new headers sent', () => {
+    const extraHeaders = {'x-lang': 'en_us'};
+
+    expect(setApiHeaders(extraHeaders)).toEqual({...defaultHeaders, ...extraHeaders});
+  });
+});

--- a/packages/utils/src/utils/setApiHeaders/index.ts
+++ b/packages/utils/src/utils/setApiHeaders/index.ts
@@ -1,0 +1,21 @@
+import isClientRender from '../isClientRender';
+
+export const defaultHeaders = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+  ...(isClientRender() && (window as any)?.__NEXT_DATA__?.props?.pageProps?.locale ?
+    {'X-Lang': (window as any)?.__NEXT_DATA__?.props?.pageProps?.locale} : {}), // this create the X-Lang Header as default for all client side requests.
+};
+
+/**
+ * This function generates a header object with our default Headers
+ * and other supplied headers
+ *
+ * @param {Object} headers
+ */
+export default function setApiHeaders (headers = {}): Record<string, string> {
+  return {
+    ...defaultHeaders,
+    ...headers,
+  };
+}


### PR DESCRIPTION
### setApiHeaders - version to test: 0.0.1-beta.6

- [x] move code
- [x] improve code (typescript)
- [x] implement tests
- [x] test on app-sitemaps
- [x] test on app-profiles